### PR TITLE
Fix HDMI_VIC display

### DIFF
--- a/edid-decode.c
+++ b/edid-decode.c
@@ -846,6 +846,7 @@ cea_vfpdb(unsigned char *x)
 }
 
 static const char *edid_cea_hdmi_modes[] = {
+    "Reserved",
     "3840x2160@30Hz",
     "3840x2160@25Hz",
     "3840x2160@24Hz",
@@ -934,7 +935,6 @@ cea_hdmi_block(unsigned char *x)
                     unsigned char vic = x[9 + b + i];
                     const char *mode;
 
-                    vic--;
                     if (vic < ARRAY_SIZE(edid_cea_hdmi_modes))
                             mode = edid_cea_hdmi_modes[vic];
                     else


### PR DESCRIPTION
Correct HDMI VIC number, which is shown off-by-one.
